### PR TITLE
Update runtime and drop mm-common

### DIFF
--- a/net.carrotindustries.usbkvm.json
+++ b/net.carrotindustries.usbkvm.json
@@ -1,7 +1,7 @@
 {
     "app-id": "net.carrotindustries.usbkvm",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "46",
+    "runtime-version": "49",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.golang"
@@ -11,7 +11,8 @@
         "--share=ipc",
         "--socket=fallback-x11",
         "--socket=wayland",
-        "--device=all"
+        "--device=all",
+        "--filesystem=xdg-run/pipewire-0:ro"
     ],
     "cleanup": [
         "*.a",
@@ -39,8 +40,8 @@
            "sources": [
                {
                    "type": "archive",
-                   "url": "https://download.gnome.org/sources/mm-common/1.0/mm-common-1.0.6.tar.xz",
-                   "sha256": "b55c46037dbcdabc5cee3b389ea11cc3910adb68ebe883e9477847aa660862e7"
+                   "url": "https://download.gnome.org/sources/mm-common/1.0/mm-common-1.0.7.tar.xz",
+                   "sha256": "494abfce781418259b1e9d8888c73af4de4b6f3be36cc75d9baa8baa0f2a7a39"
                }
            ]
         },
@@ -62,8 +63,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/glibmm/2.66/glibmm-2.66.7.tar.xz",
-                    "sha256": "fe02c1e5f5825940d82b56b6ec31a12c06c05c1583cfe62f934d0763e1e542b3"
+                    "url": "https://download.gnome.org/sources/glibmm/2.66/glibmm-2.66.8.tar.xz",
+                    "sha256": "64f11d3b95a24e2a8d4166ecff518730f79ecc27222ef41faf7c7e0340fc9329"
                 }
             ]
         },
@@ -109,8 +110,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gtkmm/3.24/gtkmm-3.24.9.tar.xz",
-                    "sha256": "30d5bfe404571ce566a8e938c8bac17576420eb508f1e257837da63f14ad44ce"
+                    "url": "https://download.gnome.org/sources/gtkmm/3.24/gtkmm-3.24.10.tar.xz",
+                    "sha256": "7ab7e2266808716e26c39924ace1fb46da86c17ef39d989624c42314b32b5a76"
                 }
             ]
         },
@@ -121,8 +122,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/libusb/hidapi/archive/hidapi-0.14.0.tar.gz",
-                    "sha256": "a5714234abe6e1f53647dd8cba7d69f65f71c558b7896ed218864ffcf405bcbd"
+                    "url": "https://github.com/libusb/hidapi/archive/hidapi-0.15.0.tar.gz",
+                    "sha256": "5d84dec684c27b97b921d2f3b73218cb773cf4ea915caee317ac8fc73cef8136"
                 }
             ]
         },

--- a/net.carrotindustries.usbkvm.json
+++ b/net.carrotindustries.usbkvm.json
@@ -19,7 +19,6 @@
         "*.la",
         "/include",
         "/lib/*/*.h",
-        "/share/pkgconfig",
         "/lib/atkmm-1.6",
         "/lib/cairomm-1.0",
         "/lib/gdkmm-3.0",
@@ -31,23 +30,15 @@
         "/lib/pkgconfig",
         "/lib/cmake",
         "/lib/sigc++-3.0",
-        "/lib/sigc++-2.0"
+        "/lib/sigc++-2.0",
+        "/share/devhelp",
+        "/share/doc",
+        "/share/pkgconfig"
     ],
     "modules": [
         {
-           "name": "mm-common",
-           "cleanup": [ "*" ],
-           "sources": [
-               {
-                   "type": "archive",
-                   "url": "https://download.gnome.org/sources/mm-common/1.0/mm-common-1.0.7.tar.xz",
-                   "sha256": "494abfce781418259b1e9d8888c73af4de4b6f3be36cc75d9baa8baa0f2a7a39"
-               }
-           ]
-        },
-        {
             "name": "sigc++",
-            "config-opts": [ "--disable-documentation" ],
+            "buildsystem": "meson",
             "sources": [
                 {
                     "type": "archive",
@@ -70,7 +61,7 @@
         },
         {
             "name": "cairomm",
-            "config-opts": [ "--disable-documentation" ],
+            "buildsystem": "meson",
             "sources": [
                 {
                     "type": "archive",


### PR DESCRIPTION
Based on: https://github.com/flathub/net.carrotindustries.usbkvm/pull/4

---

When building libxml++, libsigc++ and glibmm from current release tarballs,
mm-common is no longer needed. See:
- libxml++ [NEWS](https://github.com/libxmlplusplus/libxmlplusplus/blob/e37ba77403cbbdccf1975043bd05df881c4ed024/NEWS#L187):
> Do not require mm-common during the tarball build.

- libsig++ [NEWS](https://github.com/libsigcplusplus/libsigcplusplus/blob/5cdc3cfba613ced119e2853bce85a070dbcca46a/NEWS#L712):
> New build system based on mm-common. The mm-common module is now
> required for building from the git repository, but not for builds
> of release archives.

- glibmm [NEWS](https://github.com/GNOME/glibmm/blob/efa83dfd2e1fb413eb8da9af870f1ffd8a632399/NEWS#L3741):
> Remove the dependency on mm-common during the tarball build.

Thanks to @yakushabb for bringing this to my attention in https://github.com/flathub/org.kde.kmymoney/pull/78

Source: https://github.com/flathub/org.kde.kmymoney/pull/80